### PR TITLE
Hook play/pause/next/show/hide actions on NotifyIcon

### DIFF
--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace Elpis
         private ToolStripMenuItem _notifyMenu_Tired;
         private ToolStripMenuItem _notifyMenu_Exit;
         private System.Threading.Timer _notifyDoubleClickTimer;
-        private static Boolean _notifyDoubleClick = false;
+        private static Boolean _notifyDoubleClicked = false;
         public static Player _player;
         public static PlaylistPage _playlistPage;
         public static MainWindow _mainWindow;
@@ -653,20 +653,26 @@ namespace Elpis
             _notifyDoubleClickTimer = new System.Threading.Timer(o =>
                                         {
                                             Thread.Sleep(SystemInformation.DoubleClickTime);
-                                            if (!_notifyDoubleClick)
+                                            if (!_notifyDoubleClicked)
                                             {
                                                 _player.PlayPause();
                                             }
-                                            _notifyDoubleClick = false;
+                                            _notifyDoubleClicked = false;
                                         });
 
             _notify.MouseDoubleClick += ((o, e) =>
                                         {
-                                            _notifyDoubleClick = true;
+                                            // Only process left mouse button double clicks
+                                            if (e.Button != MouseButtons.Left)
+                                            {
+                                                return;
+                                            }
+
+                                            _notifyDoubleClicked = true;
+                                            
                                             // Hide window if it is shown; show if it is hidden
                                             if (WindowState == WindowState.Normal)
                                             {
-                                                Microsoft.Shell.NativeMethods.ShowToFront((new WindowInteropHelper(this)).Handle);
                                                 WindowState = WindowState.Minimized;
                                                 this.Hide();
                                                 ShowInTaskbar = false; 

--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Shell;
 using BassPlayer;
 using Elpis.Hotkeys;
@@ -89,6 +90,8 @@ namespace Elpis
         private ToolStripMenuItem _notifyMenu_DownVote;
         private ToolStripMenuItem _notifyMenu_Tired;
         private ToolStripMenuItem _notifyMenu_Exit;
+        private System.Threading.Timer _notifyDoubleClickTimer;
+        private static Boolean _notifyDoubleClick = false;
         public static Player _player;
         public static PlaylistPage _playlistPage;
         public static MainWindow _mainWindow;
@@ -253,14 +256,6 @@ namespace Elpis
             {
                 LoadStation(_clo.StationToLoad);
             }
-        }
-
-        public void ShowWindow()
-        {
-            if (WindowState == WindowState.Minimized)
-                WindowState = WindowState.Normal;
-
-            Microsoft.Shell.NativeMethods.ShowToFront((new System.Windows.Interop.WindowInteropHelper(this)).Handle);
         }
 
         static void ShowHelp(OptionSet p)
@@ -654,10 +649,48 @@ namespace Elpis
                               ContextMenuStrip = _notifyMenu,
                           };
 
-            _notify.DoubleClick += ((o, e) =>
+            // Timer is used to distinguish between mouse single and double clicks
+            _notifyDoubleClickTimer = new System.Threading.Timer(o =>
                                         {
-                                            ShowWindow();
+                                            Thread.Sleep(SystemInformation.DoubleClickTime);
+                                            if (!_notifyDoubleClick)
+                                            {
+                                                _player.PlayPause();
+                                            }
+                                            _notifyDoubleClick = false;
                                         });
+
+            _notify.MouseDoubleClick += ((o, e) =>
+                                        {
+                                            _notifyDoubleClick = true;
+                                            // Hide window if it is shown; show if it is hidden
+                                            if (WindowState == WindowState.Normal)
+                                            {
+                                                Microsoft.Shell.NativeMethods.ShowToFront((new WindowInteropHelper(this)).Handle);
+                                                WindowState = WindowState.Minimized;
+                                                this.Hide();
+                                                ShowInTaskbar = false; 
+                                            }
+                                            else
+                                            {
+                                                Microsoft.Shell.NativeMethods.ShowToFront((new WindowInteropHelper(this)).Handle);
+                                            }
+                                        });
+
+
+            _notify.MouseClick += ((o, e) =>
+                                        {
+                                            if (e.Button == MouseButtons.Left)
+                                            {
+                                                // Play or pause only in the event of single click
+                                                _notifyDoubleClickTimer.Change(0, 0);
+                                            }
+                                            else if (e.Button == MouseButtons.Middle)
+                                            {
+                                                _player.Next();
+                                            }
+                                        });
+
             _notify.ContextMenuStrip.Opening += ((o, e) => LoadNotifyMenu());
 
             _notify.Visible = true;


### PR DESCRIPTION
Actions are triggered with mouse buttons as follows:
- Left double click: Show main window if it is hidden or hide if it is shown
- Left single click: Pause/Play
- Middle click: Next track

I also removed the ShowWindow() method since it is only used in one place. This removes not needed indirection layer.

This pull request touches upon issue #66. Not exactly as requested but, in my opinion, in more convenient way.
