### PR TITLE
Issue #54 Bug Fix.

### DIFF
--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -210,8 +210,12 @@ namespace Elpis
 
                 if (loc.X != -1 && loc.Y != -1)
                 {
-                    this.Left = loc.X;
-                    this.Top = loc.Y;
+                    // Bug Fix: Issue #54, make sure that the initial window location is
+                    // always fully within the monitor bounds.
+                    this.Left = Math.Max(0, Math.Min(loc.X, 
+                        SystemParameters.VirtualScreenWidth - this.ActualWidth));
+                    this.Top = Math.Max(0, Math.Min(loc.Y,
+                        SystemParameters.VirtualScreenHeight - this.ActualHeight));
                 }
 
                 if (size.Width != 0 && size.Height != 0)

--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -211,7 +211,9 @@ namespace Elpis
                 if (loc.X != -1 && loc.Y != -1)
                 {
                     // Bug Fix: Issue #54, make sure that the initial window location is
-                    // always fully within the monitor bounds.
+                    // always fully within the virtual screen bounds.
+                    // Unfortunately may not preserve window location when primary display is not left most
+                    // but it eliminates the missing window problem in most situations.
                     this.Left = Math.Max(0, Math.Min(loc.X, 
                         SystemParameters.VirtualScreenWidth - this.ActualWidth));
                     this.Top = Math.Max(0, Math.Min(loc.Y,


### PR DESCRIPTION
Operating System: 
Windows 10

Current Elpis Version: 
1.6

Using proxy/vpn:
No

Steps to reproduce the problem:
See #54.

Problem: 
See #54. This bug fix addresses issues that arise when using multiple display setups. Multiple monitors change the dimensions of the Virtual Screen which can lead to invalid Window X/Y being saved at application close. When app loads coordinates from file it repositions itself relative to the virtual screen which is off screen in actual screen coordinates.

This fix prevents main window from loading a position outside of the virtual screen. When monitors are in non-linear positions the window's placement is floored or ceilinged to the closest monitor edge.

NOTE: This fix should be supplemented by storing window coordinates in virtual screen coordinates so window location is property saved but I am not sure how best to do this. This fix should work for most situations though.
