### PR TITLE
Fixing issue #104

### DIFF
--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -1547,9 +1547,9 @@ namespace Elpis
                     {
                         case PLAY:
                             {
-                                string tipText = _player.CurrentSong.SongTitle;
+                                string tipText = _player.CurrentSong.SongTitle.Replace("&", "&&");
                                 _notify.BalloonTipTitle = "Playing: " + tipText;
-                                _notify.BalloonTipText = " by " + _player.CurrentSong.Artist;
+                                _notify.BalloonTipText = " by " + _player.CurrentSong.Artist.Replace("&", "&&");
                                 break;
                             }
                         case PAUSE:


### PR DESCRIPTION
Microsoft reserves '&' in their OS windows to allow for alt hotkeys.  These can be escaped by adding a second ampersand.

Issue #104 
