### PR TITLE
Opened Elpis from Tray when run

### DIFF
--- a/Elpis/App.xaml.cs
+++ b/Elpis/App.xaml.cs
@@ -95,6 +95,10 @@ namespace Elpis
         #region ISingleInstanceApp Members
         public bool SignalExternalCommandLineArgs(IList<string> args)
         {
+            ((Elpis.MainWindow)MainWindow).Show();
+            ((Elpis.MainWindow)MainWindow).Activate();
+            ((Elpis.MainWindow)MainWindow).WindowState = WindowState.Normal;
+            ((Elpis.MainWindow)MainWindow).ShowInTaskbar = true;
             return HandleCommandLine(args);
         }
 


### PR DESCRIPTION
If a second instance of Elpis is run, the first instance of Elpis opens
from the system tray instead of doing nothing.