### PR TITLE
Stop issue of app being brought to front when control command is sent via command line

### DIFF
--- a/Elpis/App.xaml.cs
+++ b/Elpis/App.xaml.cs
@@ -96,10 +96,16 @@ namespace Elpis
         #region ISingleInstanceApp Members
         public bool SignalExternalCommandLineArgs(IList<string> args)
         {
-            ((Elpis.MainWindow)MainWindow).Show();
-            ((Elpis.MainWindow)MainWindow).Activate();
-            ((Elpis.MainWindow)MainWindow).WindowState = WindowState.Normal;
-            ((Elpis.MainWindow)MainWindow).ShowInTaskbar = true;
+            //only bring app to front if called with no arguments.  If argument was passed assume user
+            //is calling exe for control purposes only and does not want the app to be brought to front
+            if (args.Count == 1)
+            {
+                ((Elpis.MainWindow)MainWindow).Show();
+                ((Elpis.MainWindow)MainWindow).Activate();
+                ((Elpis.MainWindow)MainWindow).WindowState = WindowState.Normal;
+                ((Elpis.MainWindow)MainWindow).ShowInTaskbar = true;
+            }
+
             return HandleCommandLine(args);
         }
 


### PR DESCRIPTION
Hi,

I have integrated elpis with my home automation system and control it using the command line arguments (e.g. elpis.exe --playpause) However there is a problem of when you do this while the app is minimized the the calling of the command with cause the app to be un minimized and brought to the front

I have made these changes to prevent the issue.

I have preserved the bringing to front when the app is called without arguments as this seems useful.

Regards,
Erik