### PR TITLE
BugFix from Pinguem.ru competition

### DIFF
--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -929,7 +929,7 @@ namespace Elpis
 
         public static bool Next()
         {
-            if ((DateTime.Now - lastTimeSkipped).Seconds > 20)
+            if ((DateTime.Now - lastTimeSkipped).TotalSeconds > 20)
             {
                 System.Windows.Application.Current.Dispatcher.Invoke((Action)(() =>
                 {

--- a/Libs/BassPlayer/BassPlayer.cs
+++ b/Libs/BassPlayer/BassPlayer.cs
@@ -471,7 +471,6 @@ namespace BassPlayer
                     }
 
                     _StreamVolume = value;
-                    _StreamVolume = value;
                     Bass.BASS_SetConfig(BASSConfig.BASS_CONFIG_GVOL_STREAM, _StreamVolume*100);
                 }
             }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: 

- V3008 The '_StreamVolume' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 474, 473. BassPlayer BassPlayer.cs 474

- V3118 Seconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. Elpis MainWindow.xaml.cs 932