### PR TITLE
fix null reference error when starting with stationName command line flag

### DIFF
--- a/Libs/PandoraSharpPlayer/Player.cs
+++ b/Libs/PandoraSharpPlayer/Player.cs
@@ -624,11 +624,14 @@ namespace PandoraSharpPlayer
 
         public Station GetStationFromName(string stationName)
         {
-            foreach (Station s in Stations)
+            if (Stations != null)
             {
-                if (stationName == s.Name)
+                foreach (Station s in Stations)
                 {
-                    return s;
+                    if (stationName == s.Name)
+                    {
+                        return s;
+                    }
                 }
             }
 


### PR DESCRIPTION
If you launch Elpis, then launch Elpis again within a few seconds with  --s="MyStaion"  you will get a crash with a null ref exception.

This stops the crash by checking if the Station list is null.  The station will still not play, but at least there is no crash and the user can try again after the stations finish loading.