### PR TITLE
Fix #217 : HTML characters in song/album/station titles are decoded.

### DIFF
--- a/Libs/PandoraSharp/Song.cs
+++ b/Libs/PandoraSharp/Song.cs
@@ -44,8 +44,8 @@ namespace PandoraSharp
             _pandora = p;
 
             TrackToken = (string)song["trackToken"];
-            Artist = (string)song["artistName"];
-            Album = (string)song["albumName"];
+            Artist = WebUtility.HtmlDecode((string)song["artistName"]);
+            Album = WebUtility.HtmlDecode((string)song["albumName"]);
 
             AmazonAlbumID = (string)song["amazonAlbumDigitalAsin"];
             AmazonTrackID = (string)song["amazonSongDigitalAsin"];
@@ -108,7 +108,7 @@ namespace PandoraSharp
 
             Rating = (((int)song["songRating"]) > 0 ? SongRating.love : SongRating.none);
             StationID = (string)song["stationId"];
-            SongTitle = (string)song["songName"];
+            SongTitle = WebUtility.HtmlDecode((string)song["songName"]);
             SongDetailUrl = (string)song["songDetailUrl"];
             ArtistDetailUrl = (string)song["artistDetailUrl"];
             AlbumDetailUrl = (string)song["albumDetailUrl"];

--- a/Libs/PandoraSharp/Station.cs
+++ b/Libs/PandoraSharp/Station.cs
@@ -52,7 +52,7 @@ namespace PandoraSharp
             IdToken = d["stationToken"].ToString();
             IsCreator = !d["isShared"].ToObject<bool>();
             IsQuickMix = d["isQuickMix"].ToObject<bool>();
-            Name = d["stationName"].ToString();
+            Name = WebUtility.HtmlDecode(d["stationName"].ToString());
             InfoUrl = (string)d["stationDetailUrl"];
 
             if (IsQuickMix)


### PR DESCRIPTION
Before:  
 ![Before](https://files.bltaelmer.com/resource/external/elpis217.jpg)
After:   
![After](https://files.bltaelmer.com/resource/external/elpis217fix.jpg)