### PR TITLE
Added a default value for the Current_Color config option

### DIFF
--- a/Elpis/Config.cs
+++ b/Elpis/Config.cs
@@ -124,7 +124,7 @@ namespace Elpis
 
         //public static MapConfigEntry Misc_ForceSSL = new MapConfigEntry("Misc_ForceSSL", false);
         public static MapConfigEntry System_OutputDevice = new MapConfigEntry("System_OutputDevice", "");
-        public static MapConfigEntry Current_Color = new MapConfigEntry("Current_Color", "");
+        public static MapConfigEntry Current_Color = new MapConfigEntry("Current_Color", "grey");
     }
 
     public struct ConfigDropDownItem


### PR DESCRIPTION
The Current_Color config option did not have a default value which resulted in a crash if not added manually to the config.