### PR TITLE
Further null value bug fixes

### DIFF
--- a/Elpis/MainWindow.xaml.cs
+++ b/Elpis/MainWindow.xaml.cs
@@ -926,9 +926,7 @@ namespace Elpis
                 {
                     _player.OutputDevice = systemOutputDevice;
                 }
-#pragma warning disable CS0168 // Variable is declared but never used
                 catch (BassException bEx)
-#pragma warning restore CS0168 // Variable is declared but never used
                 {
                     _player.OutputDevice = prevOutput;
                 }
@@ -1062,9 +1060,7 @@ namespace Elpis
 
         private void LoadLogic()
         {
-#pragma warning disable CS0219 // Variable is assigned but its value is never used
             bool foundNewUpdate = false;
-#pragma warning restore CS0219 // Variable is assigned but its value is never used
             if (InitLogic())
             {
 #if APP_RELEASE

--- a/Elpis/Pages/Settings.xaml.cs
+++ b/Elpis/Pages/Settings.xaml.cs
@@ -123,8 +123,9 @@ namespace Elpis
                 primaryPaletteComboBox.Items.Add(str);
 
             primaryPaletteComboBox.SelectedValue = _config.Fields.Current_Color;
-            Swatch color = swatchesProvider.Swatches.First(a => a.Name == _config.Fields.Current_Color);
-            new PaletteHelper().ReplacePrimaryColor(color);
+            Swatch color = swatchesProvider.Swatches.FirstOrDefault(a => a.Name == _config.Fields.Current_Color);
+            if(color != null)
+                new PaletteHelper().ReplacePrimaryColor(color);
 
             _config.SaveConfig();
 
@@ -197,7 +198,8 @@ namespace Elpis
                 _player.OutputDevice = (string)cmbOutputDevice.SelectedValue;
             }
 
-            if (!_config.Fields.Current_Color.Equals(this.primaryPaletteComboBox.SelectedValue.ToString()))
+            if (this.primaryPaletteComboBox.SelectedValue != null &&
+                !_config.Fields.Current_Color.Equals(this.primaryPaletteComboBox.SelectedValue.ToString()))
             {
                 _config.Fields.Current_Color = this.primaryPaletteComboBox.SelectedValue.ToString();
 


### PR DESCRIPTION
Continuation of #231 

I found some more instances where null color values caused the application to crash in a development environment.

There was also some cleanup from #231 which left a few unnecessary Visual Studio pragmas.